### PR TITLE
Changes from upgrade of Unity to 5.6.1f1

### DIFF
--- a/Creation Sandbox/Assets/Scripts/UI/DemoScreen.cs
+++ b/Creation Sandbox/Assets/Scripts/UI/DemoScreen.cs
@@ -73,7 +73,7 @@ public class DemoScreen : MonoBehaviour {
             }
             else
             {
-                camera = rigCamera.transform.parent.transform.parent.FindChild("Camera (eye)").GetComponent<Camera>();
+                camera = rigCamera.transform.parent.transform.parent.Find("Camera (eye)").GetComponent<Camera>();
             }
 
             takeScreenshot(camera);

--- a/Creation Sandbox/Assets/SteamVR/Scripts/SteamVR_RenderModel.cs
+++ b/Creation Sandbox/Assets/SteamVR/Scripts/SteamVR_RenderModel.cs
@@ -718,7 +718,7 @@ public class SteamVR_RenderModel : MonoBehaviour
 			child.localPosition = componentTransform.pos;
 			child.localRotation = componentTransform.rot;
 
-			var attach = child.FindChild(k_localTransformName);
+			var attach = child.Find(k_localTransformName);
 			if (attach != null)
 			{
 				var attachTransform = new SteamVR_Utils.RigidTransform(componentState.mTrackingToComponentLocal);

--- a/Creation Sandbox/Assets/VRTK/Examples/Resources/Scripts/Archery/ArrowNotch.cs
+++ b/Creation Sandbox/Assets/VRTK/Examples/Resources/Scripts/Archery/ArrowNotch.cs
@@ -9,7 +9,7 @@
 
         private void Start()
         {
-            arrow = transform.FindChild("Arrow").gameObject;
+            arrow = transform.Find("Arrow").gameObject;
             obj = GetComponent<VRTK_InteractableObject>();
         }
 

--- a/Creation Sandbox/Assets/VRTK/Examples/Resources/Scripts/LightSaber.cs
+++ b/Creation Sandbox/Assets/VRTK/Examples/Resources/Scripts/LightSaber.cs
@@ -55,7 +55,7 @@
             if (beamActive)
             {
                 Color bladeColor = Color.Lerp(activeColor, targetColor, Mathf.PingPong(Time.time, 1));
-                blade.transform.FindChild("Beam").GetComponent<MeshRenderer>().material.color = bladeColor;
+                blade.transform.Find("Beam").GetComponent<MeshRenderer>().material.color = bladeColor;
 
                 if (bladeColor == targetColor)
                 {

--- a/Creation Sandbox/Assets/VRTK/Scripts/Helper/ConsoleViewer.cs
+++ b/Creation Sandbox/Assets/VRTK/Scripts/Helper/ConsoleViewer.cs
@@ -67,9 +67,9 @@ namespace VRTK
             { LogType.Log, infoMessage },
             { LogType.Warning, warningMessage }
         };
-            scrollWindow = transform.FindChild("Panel/Scroll View").GetComponent<ScrollRect>();
-            consoleRect = transform.FindChild("Panel/Scroll View/Viewport/Content").GetComponent<RectTransform>();
-            consoleOutput = transform.FindChild("Panel/Scroll View/Viewport/Content/ConsoleOutput").GetComponent<Text>();
+            scrollWindow = transform.Find("Panel/Scroll View").GetComponent<ScrollRect>();
+            consoleRect = transform.Find("Panel/Scroll View/Viewport/Content").GetComponent<RectTransform>();
+            consoleOutput = transform.Find("Panel/Scroll View/Viewport/Content/ConsoleOutput").GetComponent<Text>();
 
             consoleOutput.fontSize = fontSize;
             ClearLog();

--- a/Creation Sandbox/Assets/VRTK/Scripts/Highlighters/VRTK_OutlineObjectCopyHighlighter.cs
+++ b/Creation Sandbox/Assets/VRTK/Scripts/Highlighters/VRTK_OutlineObjectCopyHighlighter.cs
@@ -104,7 +104,7 @@ namespace VRTK.Highlighters
             }
             else if (customOutlineModelPath != "")
             {
-                var getChildModel = transform.FindChild(customOutlineModelPath);
+                var getChildModel = transform.Find(customOutlineModelPath);
                 customOutlineModel = (getChildModel ? getChildModel.gameObject : null);
             }
 

--- a/Creation Sandbox/Assets/VRTK/Scripts/VRTK_ControllerTooltips.cs
+++ b/Creation Sandbox/Assets/VRTK/Scripts/VRTK_ControllerTooltips.cs
@@ -98,7 +98,7 @@ namespace VRTK
 
             for (int i = 0; i < availableButtons.Length; i++)
             {
-                buttonTooltips[i] = transform.FindChild(availableButtons[i].ToString()).gameObject;
+                buttonTooltips[i] = transform.Find(availableButtons[i].ToString()).gameObject;
             }
         }
 
@@ -210,7 +210,7 @@ namespace VRTK
             }
             else
             {
-                returnTransform = transform.parent.FindChild("Model/" + findTransform + "/attach");
+                returnTransform = transform.parent.Find("Model/" + findTransform + "/attach");
             }
 
             return returnTransform;

--- a/Creation Sandbox/Assets/VRTK/Scripts/VRTK_ObjectTooltip.cs
+++ b/Creation Sandbox/Assets/VRTK/Scripts/VRTK_ObjectTooltip.cs
@@ -58,15 +58,15 @@ namespace VRTK
 
         private void SetContainer()
         {
-            transform.FindChild("TooltipCanvas").GetComponent<RectTransform>().sizeDelta = containerSize;
-            var tmpContainer = transform.FindChild("TooltipCanvas/UIContainer");
+            transform.Find("TooltipCanvas").GetComponent<RectTransform>().sizeDelta = containerSize;
+            var tmpContainer = transform.Find("TooltipCanvas/UIContainer");
             tmpContainer.GetComponent<RectTransform>().sizeDelta = containerSize;
             tmpContainer.GetComponent<Image>().color = containerColor;
         }
 
         private void SetText(string name)
         {
-            var tmpText = transform.FindChild("TooltipCanvas/" + name).GetComponent<Text>();
+            var tmpText = transform.Find("TooltipCanvas/" + name).GetComponent<Text>();
             tmpText.material = Resources.Load("UIText") as Material;
             tmpText.text = displayText.Replace("\\n", "\n");
             tmpText.color = fontColor;
@@ -75,7 +75,7 @@ namespace VRTK
 
         private void SetLine()
         {
-            line = transform.FindChild("Line").GetComponent<LineRenderer>();
+            line = transform.Find("Line").GetComponent<LineRenderer>();
             line.material = Resources.Load("TooltipLine") as Material;
             line.material.color = lineColor;
             line.SetColors(lineColor, lineColor);

--- a/Creation Sandbox/ProjectSettings/ProjectVersion.txt
+++ b/Creation Sandbox/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 5.6.0f3
+m_EditorVersion: 5.6.1f1


### PR DESCRIPTION
Upon upgrade to Unity 5.6.1f1, certain assests are re-imported.
This patch checks in those upgraded assets.